### PR TITLE
switch from IMG_XXX constants to IMAGETYPE_XXX constants

### DIFF
--- a/mod/wall_attach.php
+++ b/mod/wall_attach.php
@@ -24,7 +24,7 @@ function wall_attach_post(&$a) {
 	if($_FILES['userfile']['tmp_name']) {
 		$x = @getimagesize($_FILES['userfile']['tmp_name']);
 		logger('getimagesize: ' . print_r($x,true), LOGGER_DATA); 
-		if(($x) && ($x[2] === IMG_GIF || $x[2] === IMG_JPG || $x[2] === IMG_JPEG || $x[2] === IMG_PNG)) {
+		if(($x) && ($x[2] === IMAGETYPE_GIF || $x[2] === IMAGETYPE_JPEG || $x[2] === IMAGETYPE_PNG)) {
 			$args = array( 'source' => 'editor', 'visible' => 0, 'contact_allow' => array($channel['channel_hash']));
 			$ret = photo_upload($channel,$observer,$args);
 			if($ret['success']) {


### PR DESCRIPTION
> Note that, if you're going to be a good programmer and use named constatnts (IMAGETYPE_JPEG) rather than their values (2), you want to use the IMAGETYPE variants - IMAGETYPE_JPEG, IMAGETYPE GIF, IMAGETYPE_PNG, etc.  For some reason, somebody made a horrible decision, and IMG_PNG is actually 4 in my version of PHP, while IMAGETYPE_PNG is 3.  It took me a while to figure out why comparing the type against IMG_PNG was failing...

http://php.net/manual/en/function.getimagesize.php