### PR TITLE
change sh to bash in shebang to make scripts work

### DIFF
--- a/util/add_addon_repo
+++ b/util/add_addon_repo
@@ -1,4 +1,4 @@
-#!/bin/sh -f
+#!/bin/bash -f
 
 if [ $# -ne 2 ]; then
 	echo usage: $0 repo_url nickname

--- a/util/add_theme_repo
+++ b/util/add_theme_repo
@@ -1,4 +1,4 @@
-#!/bin/sh -f
+#!/bin/bash -f
 
 
 if [ $# -ne 2 ]; then

--- a/util/add_widget_repo
+++ b/util/add_widget_repo
@@ -1,4 +1,4 @@
-#!/bin/sh -f
+#!/bin/bash -f
 
 if [ $# -ne 2 ]; then
 	echo usage: $0 repo_url nickname

--- a/util/update_addon_repo
+++ b/util/update_addon_repo
@@ -1,4 +1,4 @@
-#!/bin/sh -f
+#!/bin/bash -f
 
 if [ $# -ne 1 ]; then
 	echo usage: $0 repository

--- a/util/update_theme_repo
+++ b/util/update_theme_repo
@@ -1,4 +1,4 @@
-#!/bin/sh -f
+#!/bin/bash -f
 
 
 if [ $# -ne 1 ]; then

--- a/util/update_widget_repo
+++ b/util/update_widget_repo
@@ -1,4 +1,4 @@
-#!/bin/sh -f
+#!/bin/bash -f
 
 if [ $# -ne 1 ]; then
 	echo usage: $0 repository


### PR DESCRIPTION
On Debian Jessie, the scripts choked on the "filelist=(`ls ...`)" syntax when called with sh instead of bash.