### PR TITLE
Require comment perms only for own posts, allow senders to deliver co…

### DIFF
--- a/include/zot.php
+++ b/include/zot.php
@@ -1560,7 +1560,17 @@ function process_delivery($sender, $arr, $deliveries, $relay, $public = false, $
 
 		$tag_delivery = tgroup_check($channel['channel_id'],$arr);
 
-		$perm = (($arr['mid'] == $arr['parent_mid']) ? 'send_stream' : 'post_comments');
+		if ($arr['mid'] == $arr['parent_mid']){
+			$perm = 'send_stream';
+		}
+		else{
+			$r = q("select item_owner from item where item.mid == '%s' limit 1",
+				dbesc($arr['parent_mid']));
+			if($channel['channel_hash'] == $r[0]['item_owner'])
+				$perm = 'post_comments';
+			else
+				$perm = 'send_stream';
+		}
 
 
 		// This is our own post, possibly coming from a channel clone


### PR DESCRIPTION
…mments using stream perms.

I've been running this for a couple of weeks and nothing blew up. : P

In short: comment arrives, if destination channel owns the post, sender needs comment perms, otherwise, sender needs send_stream.

This way we get comments to posts in our stream that are not owned by us, even if we don't allow the owners of those posts to comment on our posts.